### PR TITLE
Ajustes funcionamento ValidatesRequests

### DIFF
--- a/src/Exceptions/JsonApiException.php
+++ b/src/Exceptions/JsonApiException.php
@@ -101,22 +101,6 @@ class JsonApiException extends \Exception
   }
 
   /**
-   * @return int|null
-   */
-  public function getCode(): ?int
-  {
-    return $this->code;
-  }
-
-  /**
-   * @param int|null $code
-   */
-  public function setCode(?int $code): void
-  {
-    $this->code = $code;
-  }
-
-  /**
    * @return string|null
    */
   public function getTitle(): ?string

--- a/src/Validation/ValidatesRequests.php
+++ b/src/Validation/ValidatesRequests.php
@@ -36,8 +36,8 @@ trait ValidatesRequests
 
   /**
    * @param $method
-   * @param $parameters
-   * @return array
+   * @param array $parameters
+   * @return mixed
    */
   protected function dataValidation($method, array $parameters)
   {
@@ -45,7 +45,10 @@ trait ValidatesRequests
 
     return collect($validation)->map(function ($errors, $rule) {
       foreach ($errors as $error) {
-        return new JsonApiException($error, 'Invalid Attribute: ' . $rule, 422);
+        $e = new JsonApiException($error, 422);
+        $e->setTitle('Invalid Attribute: ' . $rule);
+
+        return $e;
       }
     })->toArray();
   }


### PR DESCRIPTION
Remoção do metodo getCode() e setCode() que estavam com problema e modificado método dataValidation() de ValidatesRequests.php.